### PR TITLE
Offline Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Options:
       --timeout <TIMEOUT>    How long to wait in seconds until timeout is triggered (for live capture) [default: 120]
   -v, --verbose...           How verbose the output should be, can be set up to 3 times. Has no effect if RUST_LOG is set
   -l, --log-path <LOG_PATH>  Path to output log to
+      --database <DB_PATH>   Path to offline database [default: OS-defined TEMP directory]
+      --no-save              Do not save an offline database
   -h, --help                 Print help
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ struct Args {
     /// Path to output log to
     #[arg(short, long)]
     log_path: Option<PathBuf>,
+    /// Path to database
+    #[arg(long, default_value = "database")]
+    database: PathBuf,
 }
 
 fn main() {
@@ -42,7 +45,7 @@ fn main() {
 
     debug!(?args);
 
-    let database = Database::new_from_source();
+    let database = Database::new_from_source(&args.database);
     let sniffer = GameSniffer::new().set_initial_keys(database.keys().clone());
     let exporter = OptimizerExporter::new(database);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,10 @@ struct Args {
     /// Path to output log to
     #[arg(short, long)]
     log_path: Option<PathBuf>,
-    /// Path to database
+    /// Switch for disabling saving database to local storage
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    no_save: bool,
+    /// Path to local database for saving/loading
     #[arg(long, default_value = "database")]
     database: PathBuf,
 }
@@ -45,7 +48,7 @@ fn main() {
 
     debug!(?args);
 
-    let database = Database::new_from_source(&args.database);
+    let database = Database::new_from_source(!args.no_save, &args.database);
     let sniffer = GameSniffer::new().set_initial_keys(database.keys().clone());
     let exporter = OptimizerExporter::new(database);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
 
     debug!(?args);
 
-    let database = Database::new_from_online();
+    let database = Database::new_from_source();
     let sniffer = GameSniffer::new().set_initial_keys(database.keys().clone());
     let exporter = OptimizerExporter::new(database);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ struct Args {
     #[arg(long, action = clap::ArgAction::SetTrue)]
     no_save: bool,
     /// Path to local database for saving/loading
-    #[arg(long, default_value = "database")]
+    #[arg(long, default_value = "__temp_dir__")]
     database: PathBuf,
 }
 


### PR DESCRIPTION
## Making a draft pull request to begin discussing implementation details for this feature

I've made some changes to get started, but nothing is set in stone and can be changed as need be.

---

### Overview

Adds support for specifying a download directory for loading & saving necessary database config files.

### Details

* There are two new command-line arguments:
    * `--no-save` = do not save database locally
    * `--database <PATH>` = where to save and/or load the local database to/from. default is "database"
* File system errors when trying to load from the local database will fallback to fetching from online sources
* File system errors when trying to save the local database will silently fail, but the rest of the program should still run

Essentially, the `--database` arg tells it where it should be looking for the local database and the `--no-save` arg explicitly tells it not to save, otherwise the default behavior is to always save.

### Notes

I'm storing the SHA hash of the latest commit as versioning information for the local database files. So, when checking if it needs to update its local database, it's doing a simple comparison on the latest commit's hash and what we have saved to see if they are the same; if they aren't then we assume our database is behind and will re-download those files.

<ins>**Important**:</ins> `reliquary` repo will also need to be updated with `Serialize` derivations on most types to allow writing those types to file using serde. I can make a separate PR for that.