### PR TITLE
Disable overflow-checks in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "reliquary-archiver"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.0",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ tag = "v1.0.1"
 [profile.release]
 opt-level = "z"  # optimize for size
 lto = true
+overflow-checks = false     # Disable integer overflow checks.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reliquary-archiver"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/IceDynamix/reliquary-archiver"


### PR DESCRIPTION
Avoid a multiply overflow crash when running without '--release' flag.