### PR TITLE
Get absolute path for written archive file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
     if let Some(export) = export {
         let file = File::create(&args.output).unwrap();
         serde_json::to_writer_pretty(&file, &export).unwrap();
-        info!("wrote output to {}", &args.output.display());
+        info!("wrote output to {}", &args.output.canonicalize().unwrap().display());
     } else {
         warn!("skipped writing output");
     }


### PR DESCRIPTION
My only issue with this approach is the result of `canonicalize()` being interesting on windows. I see ways to strip out the leading `\\?\` but since it's just for logging I don't think it's a big enough deal.

```shell
2024-06-07T18:22:36.937509Z  INFO reliquary_archiver: attempting to write to \\?\C:\Users\anime\repos\reliquary-archiver\archive_output.json
```

Closes #23 