### PR TITLE
chore: generate lockfile without building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           toml set Cargo.toml package.version ${{inputs.nextVersion}} > Cargo.toml.tmp
           rm Cargo.toml
           mv Cargo.toml.tmp Cargo.toml
-          cargo build
+          cargo generate-lockfile
       - name: Push updated version
         run: |
           git config user.name "reliquary-archiver bot"


### PR DESCRIPTION
Fixes the release workflow.

See working example:
https://github.com/emmachase/reliquary-archiver/actions/runs/10456799367
https://github.com/emmachase/reliquary-archiver/releases/tag/v0.1.9