### PR TITLE
Download resources in build script instead of at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ homepage = "https://github.com/IceDynamix/reliquary-archiver"
 
 [dependencies]
 base64 = "0.22.1"
-clap = { version = "4.5.14", features = ["derive"] }
+clap = { version = "4.5.16", features = ["derive"] }
 color-eyre = "0.6.3"
 pcap = "2.0.0"
 protobuf = "~3.4.0" # match the protobuf version used in reliquary-codegen
-serde = { version = "1.0.205", features = ["derive"] }
-serde_json = "1.0.122"
+serde = { version = "1.0.208", features = ["derive"] }
+serde_json = "1.0.125"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 ureq = { version = "2.10.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,12 @@ serde = { version = "1.0.205", features = ["derive"] }
 serde_json = "1.0.122"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
-ureq = { version = "2.10.1", features = ["json"] }
+ureq = { version = "2.10.1" }
+reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v3.1.0" }
 
-[dependencies.reliquary]
-git = "https://github.com/IceDynamix/reliquary"
-tag = "v3.1.0"
+[build-dependencies]
+ureq = { version = "2.10.1", features = ["json"] }
+reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v3.1.0" }
 
 [profile.release]
 opt-level = "z"  # optimize for size

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ to output logs to a file, provide `--log-path <path>`. file logs will always be 
     to this directory was enough to link successfully
 - `cargo build` / `cargo run`
 
+note that the necessary resource files are downloaded in the build script and compiled into the binary.
+
 ## library
 
 want to do more with packet parsing? check out the

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,54 @@
+use std::env;
+use std::fs::File;
+use std::path::Path;
+
+use reliquary::resource::excel::{
+    AvatarConfigMap, AvatarSkillTreeConfigMap, EquipmentConfigMap, MultiplePathAvatarConfigMap,
+    RelicConfigMap, RelicMainAffixConfigMap, RelicSetConfigMap, RelicSubAffixConfigMap,
+};
+use reliquary::resource::ResourceMap;
+use ureq::serde_json::Value;
+
+const BASE_RESOURCE_URL: &str = "https://raw.githubusercontent.com/Dimbreath/StarRailData/master";
+const KEY_URL: &str =
+    "https://raw.githubusercontent.com/juliuskreutz/stardb-exporter/master/keys.json";
+
+fn main() {
+    println!("cargo::rerun-if-changed=Cargo.toml");
+
+    download_config::<AvatarConfigMap>();
+    download_config::<AvatarSkillTreeConfigMap>();
+    download_config::<EquipmentConfigMap>();
+    download_config::<MultiplePathAvatarConfigMap>();
+    download_config::<RelicConfigMap>();
+    download_config::<RelicMainAffixConfigMap>();
+    download_config::<RelicSetConfigMap>();
+    download_config::<RelicSubAffixConfigMap>();
+
+    download_and_write_to_out(
+        "TextMapEN.json",
+        format!("{BASE_RESOURCE_URL}/TextMap/TextMapEN.json").as_str(),
+    );
+    download_and_write_to_out("keys.json", KEY_URL);
+}
+
+fn download_config<T: ResourceMap>() {
+    let file_name = T::get_json_name();
+
+    let url = format!("{BASE_RESOURCE_URL}/ExcelOutput/{file_name}");
+
+    download_and_write_to_out(file_name, &url);
+}
+
+fn download_and_write_to_out(file: &str, url: &str) {
+    // downloaded files are in pretty format, deserialize and serialize
+    // to compress file size
+    let value: Value = ureq::get(url).call().unwrap().into_json().unwrap();
+
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_path = Path::new(&out_dir).join(file);
+
+    let mut file = File::create(out_path).unwrap();
+
+    ureq::serde_json::to_writer(&mut file, &value).unwrap();
+}

--- a/src/export/database.rs
+++ b/src/export/database.rs
@@ -32,6 +32,7 @@ impl Database {
         // i *would* create a fn load_local_config<T: ResourceMap + DeserializeOwned>()
         // to avoid duplicating the json file names by using T::get_json_name,
         // but concat!() only takes string literals. it doesn't even take `&'static str`!!
+        // https://github.com/rust-lang/rust/issues/53749
         Database {
             avatar_config: Self::parse_json(include_str!(concat!(
                 env!("OUT_DIR"),

--- a/src/export/database.rs
+++ b/src/export/database.rs
@@ -1,0 +1,101 @@
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
+use reliquary::resource::excel::{
+    AvatarConfigMap, AvatarSkillTreeConfigMap, EquipmentConfigMap, MultiplePathAvatarConfigMap,
+    RelicConfigMap, RelicMainAffixConfigMap, RelicSetConfigMap, RelicSubAffixConfigMap,
+};
+use reliquary::resource::text_map::TextMap;
+use serde::de::DeserializeOwned;
+use std::collections::HashMap;
+use tracing::{info, instrument};
+
+pub struct Database {
+    pub avatar_config: AvatarConfigMap,
+    pub avatar_skill_tree_config: AvatarSkillTreeConfigMap,
+    pub equipment_config: EquipmentConfigMap,
+    pub multipath_avatar_config: MultiplePathAvatarConfigMap,
+    pub relic_config: RelicConfigMap,
+    pub relic_set_config: RelicSetConfigMap,
+    pub relic_main_affix_config: RelicMainAffixConfigMap,
+    pub relic_sub_affix_config: RelicSubAffixConfigMap,
+    pub text_map: TextMap,
+    pub keys: HashMap<u32, Vec<u8>>,
+}
+
+impl Database {
+    #[instrument(name = "config_map")]
+    pub fn new() -> Self {
+        info!("using local database");
+
+        // config files are downloaded by the build script
+        //
+        // i *would* create a fn load_local_config<T: ResourceMap + DeserializeOwned>()
+        // to avoid duplicating the json file names by using T::get_json_name,
+        // but concat!() only takes string literals. it doesn't even take `&'static str`!!
+        Database {
+            avatar_config: Self::parse_json(include_str!(concat!(
+                env!("OUT_DIR"),
+                "/AvatarConfig.json"
+            ))),
+            avatar_skill_tree_config: Self::parse_json(include_str!(concat!(
+                env!("OUT_DIR"),
+                "/AvatarSkillTreeConfig.json"
+            ))),
+            equipment_config: Self::parse_json(include_str!(concat!(
+                env!("OUT_DIR"),
+                "/EquipmentConfig.json"
+            ))),
+            multipath_avatar_config: Self::parse_json(include_str!(concat!(
+                env!("OUT_DIR"),
+                "/MultiplePathAvatarConfig.json"
+            ))),
+            relic_config: Self::parse_json(include_str!(concat!(
+                env!("OUT_DIR"),
+                "/RelicConfig.json"
+            ))),
+            relic_set_config: Self::parse_json(include_str!(concat!(
+                env!("OUT_DIR"),
+                "/RelicSetConfig.json"
+            ))),
+            relic_main_affix_config: Self::parse_json(include_str!(concat!(
+                env!("OUT_DIR"),
+                "/RelicMainAffixConfig.json"
+            ))),
+            relic_sub_affix_config: Self::parse_json(include_str!(concat!(
+                env!("OUT_DIR"),
+                "/RelicSubAffixConfig.json"
+            ))),
+            text_map: Self::parse_json(include_str!(concat!(env!("OUT_DIR"), "/TextMapEN.json"))),
+            keys: Self::load_local_keys(),
+        }
+    }
+
+    fn parse_json<T: DeserializeOwned>(str: &'static str) -> T {
+        serde_json::de::from_str(str).unwrap()
+    }
+
+    fn load_local_keys() -> HashMap<u32, Vec<u8>> {
+        let keys: HashMap<u32, String> =
+            Self::parse_json(include_str!(concat!(env!("OUT_DIR"), "/keys.json")));
+        let mut keys_bytes = HashMap::new();
+
+        for (k, v) in keys {
+            keys_bytes.insert(k, BASE64_STANDARD.decode(v).unwrap());
+        }
+
+        keys_bytes
+    }
+
+    pub(crate) fn lookup_avatar_name(&self, avatar_id: u32) -> Option<String> {
+        if avatar_id == 0 {
+            return None;
+        }
+
+        if avatar_id >= 8000 {
+            Some("Trailblazer".to_owned())
+        } else {
+            let cfg = self.avatar_config.get(&avatar_id)?;
+            cfg.AvatarName.lookup(&self.text_map).map(|s| s.to_string())
+        }
+    }
+}

--- a/src/export/fribbels.rs
+++ b/src/export/fribbels.rs
@@ -5,10 +5,8 @@
 //! [kel-z's HSR-Scanner]: https://github.com/kel-z/HSR-Scanner
 use std::collections::HashMap;
 
-use base64::Engine;
-use base64::prelude::BASE64_STANDARD;
+use crate::export::database::Database;
 use protobuf::Enum;
-use reliquary::network::GameCommand;
 use reliquary::network::gen::command_id;
 use reliquary::network::gen::proto::Avatar::Avatar as ProtoCharacter;
 use reliquary::network::gen::proto::AvatarSkillTree::AvatarSkillTree as ProtoSkillTree;
@@ -21,16 +19,11 @@ use reliquary::network::gen::proto::MultiPathAvatarType::MultiPathAvatarType;
 use reliquary::network::gen::proto::PlayerGetTokenScRsp::PlayerGetTokenScRsp;
 use reliquary::network::gen::proto::Relic::Relic as ProtoRelic;
 use reliquary::network::gen::proto::RelicAffix::RelicAffix;
-use reliquary::resource::excel::*;
-use reliquary::resource::ResourceMap;
-use reliquary::resource::text_map::TextMap;
+use reliquary::network::GameCommand;
 use serde::{Deserialize, Serialize};
-use serde::de::DeserializeOwned;
 use tracing::{debug, info, info_span, instrument, trace, warn};
 
 use crate::export::Exporter;
-
-const BASE_RESOURCE_URL: &str = "https://raw.githubusercontent.com/Dimbreath/StarRailData/master";
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Export {
@@ -79,38 +72,54 @@ impl OptimizerExporter {
     }
 
     pub fn add_inventory(&mut self, bag: GetBagScRsp) {
-        let mut relics: Vec<Relic> = bag.relic_list.iter()
+        let mut relics: Vec<Relic> = bag
+            .relic_list
+            .iter()
             .filter_map(|r| export_proto_relic(&self.database, r))
             .collect();
 
-        info!(num=relics.len(), "found relics");
+        info!(num = relics.len(), "found relics");
         self.relics.append(&mut relics);
 
-        let mut light_cones: Vec<LightCone> = bag.equipment_list.iter()
+        let mut light_cones: Vec<LightCone> = bag
+            .equipment_list
+            .iter()
             .filter_map(|equip| export_proto_light_cone(&self.database, equip))
             .collect();
 
-        info!(num=light_cones.len(), "found light cones");
+        info!(num = light_cones.len(), "found light cones");
         self.light_cones.append(&mut light_cones);
     }
 
     pub fn add_characters(&mut self, characters: GetAvatarDataScRsp) {
-        let (characters, multipath_characters) = characters.avatar_list.iter()
-            .partition::<Vec<_>, _>(|a| MultiPathAvatarType::from_i32(a.base_avatar_id as i32).is_none() );
+        let (characters, multipath_characters) =
+            characters.avatar_list.iter().partition::<Vec<_>, _>(|a| {
+                MultiPathAvatarType::from_i32(a.base_avatar_id as i32).is_none()
+            });
 
-        let mut characters: Vec<Character> = characters.iter()
+        let mut characters: Vec<Character> = characters
+            .iter()
             .filter_map(|char| export_proto_character(&self.database, char))
             .collect();
 
-        info!(num=characters.len(), "found characters");
+        info!(num = characters.len(), "found characters");
         self.characters.append(&mut characters);
 
-        info!(num=multipath_characters.len(), "found multipath base avatars");
-        self.multipath_base_avatars.extend(multipath_characters.into_iter().map(|c| (c.base_avatar_id, c.clone())));
+        info!(
+            num = multipath_characters.len(),
+            "found multipath base avatars"
+        );
+        self.multipath_base_avatars.extend(
+            multipath_characters
+                .into_iter()
+                .map(|c| (c.base_avatar_id, c.clone())),
+        );
     }
 
     pub fn add_multipath_characters(&mut self, characters: GetMultiPathAvatarInfoScRsp) {
-        let mut characters: Vec<Character> = characters.multi_path_avatar_info_list.iter()
+        let mut characters: Vec<Character> = characters
+            .multi_path_avatar_info_list
+            .iter()
             .filter_map(|char| export_proto_multipath_character(&self.database, char))
             .collect();
 
@@ -123,14 +132,18 @@ impl OptimizerExporter {
             });
         }
 
-        info!(num=characters.len(), "found multipath characters");
+        info!(num = characters.len(), "found multipath characters");
         self.multipath_characters.append(&mut characters);
     }
 
     pub fn finalize_multipath_characters(&mut self) {
         // Fetch level & ascension
         for character in self.multipath_characters.iter_mut() {
-            if let Some(config) = self.database.multipath_avatar_config.get(&character.id.parse().unwrap()) {
+            if let Some(config) = self
+                .database
+                .multipath_avatar_config
+                .get(&character.id.parse().unwrap())
+            {
                 if let Some(base_avatar) = self.multipath_base_avatars.get(&config.BaseAvatarID) {
                     character.level = base_avatar.level;
                     character.ascension = base_avatar.promotion;
@@ -149,9 +162,7 @@ impl Exporter for OptimizerExporter {
                 debug!("detected uid");
                 let cmd = command.parse_proto::<PlayerGetTokenScRsp>();
                 match cmd {
-                    Ok(cmd) => {
-                        self.set_uid(cmd.uid)
-                    }
+                    Ok(cmd) => self.set_uid(cmd.uid),
                     Err(error) => {
                         warn!(%error, "could not parse token command");
                     }
@@ -161,9 +172,7 @@ impl Exporter for OptimizerExporter {
                 debug!("detected inventory packet");
                 let cmd = command.parse_proto::<GetBagScRsp>();
                 match cmd {
-                    Ok(cmd) => {
-                        self.add_inventory(cmd)
-                    }
+                    Ok(cmd) => self.add_inventory(cmd),
                     Err(error) => {
                         warn!(%error, "could not parse inventory data command");
                     }
@@ -173,9 +182,7 @@ impl Exporter for OptimizerExporter {
                 debug!("detected character packet");
                 let cmd = command.parse_proto::<GetAvatarDataScRsp>();
                 match cmd {
-                    Ok(cmd) => {
-                        self.add_characters(cmd)
-                    }
+                    Ok(cmd) => self.add_characters(cmd),
                     Err(error) => {
                         warn!(%error, "could not parse character data command");
                     }
@@ -185,16 +192,18 @@ impl Exporter for OptimizerExporter {
                 debug!("detected multipath packet (trailblazer/march 7th)");
                 let cmd = command.parse_proto::<GetMultiPathAvatarInfoScRsp>();
                 match cmd {
-                    Ok(cmd) => {
-                        self.add_multipath_characters(cmd)
-                    }
+                    Ok(cmd) => self.add_multipath_characters(cmd),
                     Err(error) => {
                         warn!(%error, "could not parse multipath data command");
                     }
                 }
             }
             _ => {
-                trace!(command_id=command.command_id, tag=command.get_command_name(), "ignored");
+                trace!(
+                    command_id = command.command_id,
+                    tag = command.get_command_name(),
+                    "ignored"
+                );
             }
         }
     }
@@ -248,96 +257,20 @@ impl Exporter for OptimizerExporter {
             },
             light_cones: self.light_cones,
             relics: self.relics,
-            characters: self.characters.into_iter()
+            characters: self
+                .characters
+                .into_iter()
                 .chain(self.multipath_characters)
                 .collect(),
         }
     }
 }
 
-pub struct Database {
-    avatar_config: AvatarConfigMap,
-    avatar_skill_tree_config: AvatarSkillTreeConfigMap,
-    equipment_config: EquipmentConfigMap,
-    multipath_avatar_config: MultiplePathAvatarConfigMap,
-    relic_config: RelicConfigMap,
-    relic_set_config: RelicSetConfigMap,
-    relic_main_affix_config: RelicMainAffixConfigMap,
-    relic_sub_affix_config: RelicSubAffixConfigMap,
-    text_map: TextMap,
-    keys: HashMap<u32, Vec<u8>>,
-}
-
-impl Database {
-    #[instrument(name = "config_map")]
-    pub fn new_from_online() -> Self {
-        info!("initializing database from online sources, this might take a while...");
-        Database {
-            avatar_config: Self::load_online_config(),
-            avatar_skill_tree_config: Self::load_online_config(),
-            equipment_config: Self::load_online_config(),
-            multipath_avatar_config: Self::load_online_config(),
-            relic_config: Self::load_online_config(),
-            relic_set_config: Self::load_online_config(),
-            relic_main_affix_config: Self::load_online_config(),
-            relic_sub_affix_config: Self::load_online_config(),
-            text_map: Self::load_online_text_map(),
-            keys: Self::load_online_keys(),
-        }
-    }
-
-    // TODO: new_from_source
-
-    fn load_online_config<T: ResourceMap + DeserializeOwned>() -> T {
-        Self::get::<T>(format!("{BASE_RESOURCE_URL}/ExcelOutput/{}", T::get_json_name()))
-    }
-    fn load_online_text_map() -> TextMap {
-        Self::get(format!("{BASE_RESOURCE_URL}/TextMap/TextMapEN.json"))
-    }
-
-    fn load_online_keys() -> HashMap<u32, Vec<u8>> {
-        let keys: HashMap<u32, String> = Self::get("https://raw.githubusercontent.com/tamilpp25/Iridium-SR/main/data/Keys.json".to_string());
-        let mut keys_bytes = HashMap::new();
-
-        for (k, v) in keys {
-            keys_bytes.insert(k, BASE64_STANDARD.decode(v).unwrap());
-        }
-
-        keys_bytes
-    }
-
-    fn get<T: DeserializeOwned>(url: String) -> T {
-        debug!(url, "requesting from resource");
-        ureq::get(&url)
-            .call()
-            .unwrap()
-            .into_json()
-            .unwrap()
-    }
-
-    pub fn keys(&self) -> &HashMap<u32, Vec<u8>> {
-        &self.keys
-    }
-
-    fn lookup_avatar_name(&self, avatar_id: u32) -> Option<String> {
-        if avatar_id == 0 {
-            return None;
-        }
-
-        if avatar_id >= 8000 {
-            Some("Trailblazer".to_owned())
-        } else {
-            let cfg = self.avatar_config.get(&avatar_id)?;
-            cfg.AvatarName.lookup(&self.text_map).map(|s| s.to_string())
-        }
-    }
-}
-
 fn format_location(avatar_id: u32) -> String {
     if avatar_id == 0 {
-        return "".to_owned();
+        "".to_owned()
     } else {
-        return avatar_id.to_string();
+        avatar_id.to_string()
     }
 }
 
@@ -347,13 +280,18 @@ fn export_proto_relic(db: &Database, proto: &ProtoRelic) -> Option<Relic> {
 
     let set_id = relic_config.SetID;
     let set_config = db.relic_set_config.get(&set_id)?;
-    let main_affix_config = db.relic_main_affix_config.get(&relic_config.MainAffixGroup, &proto.main_affix_id).unwrap();
+    let main_affix_config = db
+        .relic_main_affix_config
+        .get(&relic_config.MainAffixGroup, &proto.main_affix_id)
+        .unwrap();
 
     let id = proto.unique_id.to_string();
     let level = proto.level;
     let lock = proto.is_protected;
     let discard = proto.is_discarded;
-    let set_name = set_config.SetName.lookup(&db.text_map)
+    let set_name = set_config
+        .SetName
+        .lookup(&db.text_map)
         .map(|s| s.to_string())
         .unwrap_or("".to_string());
 
@@ -364,10 +302,11 @@ fn export_proto_relic(db: &Database, proto: &ProtoRelic) -> Option<Relic> {
 
     debug!(rarity, set_name, slot, slot, mainstat, location, "detected");
 
-    let substats = proto.sub_affix_list.iter()
+    let substats = proto
+        .sub_affix_list
+        .iter()
         .filter_map(|substat| export_substat(db, rarity, substat))
         .collect();
-
 
     Some(Relic {
         set_id: set_id.to_string(),
@@ -389,8 +328,7 @@ fn export_substat(db: &Database, rarity: u32, substat: &RelicAffix) -> Option<Su
     let cfg = db.relic_sub_affix_config.get(&rarity, &substat.affix_id)?;
     let key = sub_stat_to_export(&cfg.Property).to_string();
 
-    let mut value = substat.cnt as f32 * *cfg.BaseValue
-        + substat.step as f32 * *cfg.StepValue;
+    let mut value = substat.cnt as f32 * *cfg.BaseValue + substat.step as f32 * *cfg.StepValue;
 
     if key.ends_with('_') {
         value *= 100.0;
@@ -398,10 +336,7 @@ fn export_substat(db: &Database, rarity: u32, substat: &RelicAffix) -> Option<Su
 
     trace!(key, value, "detected substat");
 
-    Some(Substat {
-        key,
-        value,
-    })
+    Some(Substat { key, value })
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -433,7 +368,7 @@ fn slot_type_to_export(s: &str) -> &'static str {
         "FOOT" => "Feet",
         "NECK" => "Planar Sphere",
         "OBJECT" => "Link Rope",
-        _ => panic!("Unknown slot: {}", s)
+        _ => panic!("Unknown slot: {}", s),
     }
 }
 
@@ -458,7 +393,7 @@ fn main_stat_to_export(s: &str) -> &'static str {
         "ImaginaryAddedRatio" => "Imaginary DMG Boost",
         "BreakDamageAddedRatioBase" => "Break Effect",
         "SPRatioBase" => "Energy Regeneration Rate",
-        _ => panic!("Unknown main stat: {}", s)
+        _ => panic!("Unknown main stat: {}", s),
     }
 }
 
@@ -476,7 +411,9 @@ fn sub_stat_to_export(s: &str) -> &'static str {
         "StatusProbabilityBase" => "Effect Hit Rate_",
         "StatusResistanceBase" => "Effect RES_",
         "BreakDamageAddedRatioBase" => "Break Effect_",
-        _ => { panic!("Unknown sub stat: {}", s) }
+        _ => {
+            panic!("Unknown sub stat: {}", s)
+        }
     }
 }
 
@@ -496,12 +433,15 @@ pub struct LightCone {
 fn export_proto_light_cone(db: &Database, proto: &ProtoLightCone) -> Option<LightCone> {
     let cfg = db.equipment_config.get(&proto.tid)?;
     let id = cfg.EquipmentID.to_string();
-    let name = cfg.EquipmentName.lookup(&db.text_map).map(|s| s.to_string())?;
+    let name = cfg
+        .EquipmentName
+        .lookup(&db.text_map)
+        .map(|s| s.to_string())?;
 
     let level = proto.level;
     let superimposition = proto.rank;
 
-    debug!(light_cone=name, level, superimposition, "detected");
+    debug!(light_cone = name, level, superimposition, "detected");
 
     let location = format_location(proto.equip_avatar_id);
 
@@ -526,7 +466,7 @@ fn export_proto_character(db: &Database, proto: &ProtoCharacter) -> Option<Chara
     let level = proto.level;
     let eidolon = proto.rank;
 
-    debug!(character=name, level, eidolon, "detected");
+    debug!(character = name, level, eidolon, "detected");
 
     let (skills, traces) = export_skill_tree(db, &proto.skilltree_list);
 
@@ -542,7 +482,10 @@ fn export_proto_character(db: &Database, proto: &ProtoCharacter) -> Option<Chara
     })
 }
 
-fn export_proto_multipath_character(db: &Database, proto: &MultiPathAvatarInfo) -> Option<Character> {
+fn export_proto_multipath_character(
+    db: &Database,
+    proto: &MultiPathAvatarInfo,
+) -> Option<Character> {
     let id = proto.avatar_id.value() as u32;
     let name = db.lookup_avatar_name(id)?;
     let path = avatar_path_lookup(db, id)?.to_owned();
@@ -550,7 +493,7 @@ fn export_proto_multipath_character(db: &Database, proto: &MultiPathAvatarInfo) 
     let span = info_span!("character", name, path);
     let _enter = span.enter();
 
-    trace!(character=name, path, "detected");
+    trace!(character = name, path, "detected");
 
     let (skills, traces) = export_skill_tree(db, &proto.multi_path_skill_tree);
 
@@ -571,13 +514,13 @@ fn avatar_path_lookup(db: &Database, avatar_id: u32) -> Option<&'static str> {
     let hero_config = db.avatar_config.get(&avatar_id);
     let avatar_base_type = hero_config.unwrap().AvatarBaseType.as_str();
     match avatar_base_type {
-        "Knight"  => Some("Preservation"),
-        "Rogue"   => Some("Hunt"),
-        "Mage"    => Some("Erudition"),
+        "Knight" => Some("Preservation"),
+        "Rogue" => Some("Hunt"),
+        "Mage" => Some("Erudition"),
         "Warlock" => Some("Nihility"),
         "Warrior" => Some("Destruction"),
-        "Shaman"  => Some("Harmony"),
-        "Priest"  => Some("Abundance"),
+        "Shaman" => Some("Harmony"),
+        "Priest" => Some("Abundance"),
         _ => {
             debug!(?avatar_base_type, "unknown path");
             None
@@ -615,9 +558,10 @@ fn export_skill_tree(db: &Database, proto: &[ProtoSkillTree]) -> (Skills, Traces
         let span = info_span!("skill", id = skill.point_id, level);
         let _enter = span.enter();
 
-        let Some(skill_tree_config) = db.avatar_skill_tree_config
-            .get(&skill.point_id, &skill.level) else
-        {
+        let Some(skill_tree_config) = db
+            .avatar_skill_tree_config
+            .get(&skill.point_id, &skill.level)
+        else {
             warn!("could not look up skill tree config");
             continue;
         };

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -1,5 +1,6 @@
 use reliquary::network::GameCommand;
 
+pub mod database;
 pub mod fribbels;
 
 pub trait Exporter {


### PR DESCRIPTION
supercedes #11
supercedes #42, closes #33 

the resources are downloaded in the build script `build.rs` and are written to a directory defined by the env `OUT_DIR`. this `OUT_DIR` is referenced in the source files and used with `include_str!()` and `concat!()` to statically include the json strings in the binary, which are parsed at runtime.

this cuts down massively on bandwidth and startup time, at the cost of increased binary size. the binary sits at roughly 30mb now, most of which comes from the 22mb textmap. maybe there's a way to filter the textmap or we could compress the json files and decompress them during runtime. a 30mb executable should be fine though for now.