### PR TITLE
Optimize text map size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "etherparse"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21696e6dfe1057a166a042c6d27b89a46aad2ee1003e6e1e03c49d54fd3270d7"
+checksum = "b8d8a704b617484e9d867a0423cd45f7577f008c4068e2e33378f8d3860a6d73"
 dependencies = [
  "arrayvec",
 ]
@@ -1088,8 +1088,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reliquary"
-version = "6.2.0"
-source = "git+https://github.com/IceDynamix/reliquary?tag=v6.2.0#0adf7bc47848817bf1f0d97560e21ff0802dc7dc"
+version = "6.2.1"
+source = "git+https://github.com/IceDynamix/reliquary?tag=v6.2.1#3dcbb4b263e1fe657592fe5b91b4a21832c948ef"
 dependencies = [
  "base64",
  "etherparse",
@@ -1122,8 +1122,8 @@ dependencies = [
 
 [[package]]
 name = "reliquary-proc-macro"
-version = "0.1.0"
-source = "git+https://github.com/IceDynamix/reliquary?tag=v6.2.0#0adf7bc47848817bf1f0d97560e21ff0802dc7dc"
+version = "0.1.1"
+source = "git+https://github.com/IceDynamix/reliquary?tag=v6.2.1#3dcbb4b263e1fe657592fe5b91b4a21832c948ef"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ serde_json = "1.0.133"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 ureq = { version = "2.12.1" }
-reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v6.2.0" }
+reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v6.2.1" }
 
 [target.'cfg(windows)'.dependencies]
 self_update = "0.41.0"
 
 [build-dependencies]
 ureq = { version = "2.12.1", features = ["json"] }
-reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v6.2.0" }
+reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v6.2.1" }
 
 [profile.dev]
 # there's a field in the kcp protocol that hyv uses differently from the default implementation

--- a/README.md
+++ b/README.md
@@ -9,22 +9,23 @@ made to be used with [fribbels hsr optimizer](https://github.com/fribbels/hsr-op
 ## run
 
 - requires [npcap](https://npcap.com/) (windows) or `libpcap` (linux)
-  - when installing on windows, make sure to enable the "winpcap api-compatible mode".
-    if this is grayed out for you, see [here](https://github.com/IceDynamix/reliquary-archiver/issues/2)
-    for more details
-    - if you use wifi, enable `Support raw 802.11 traffic (and monitor mode) for wireless adapters`
-  - when building on Linux, set the `CAP_NET_RAW` capability on the resulting executable (via [pcap(3pcap)](https://man.archlinux.org/man/pcap.3pcap#Under~5))
-    ```sh
-    sudo setcap CAP_NET_RAW=+ep target/release/reliquary-archiver
-    ```
+    - when installing on windows, make sure to enable the "winpcap api-compatible mode".
+      if this is grayed out for you, see [here](https://github.com/IceDynamix/reliquary-archiver/issues/2)
+      for more details
+        - if you use wifi, enable `Support raw 802.11 traffic (and monitor mode) for wireless adapters`
+    - when building on Linux, set the `CAP_NET_RAW` capability on the resulting executable (
+      via [pcap(3pcap)](https://man.archlinux.org/man/pcap.3pcap#Under~5))
+      ```sh
+      sudo setcap CAP_NET_RAW=+ep target/release/reliquary-archiver
+      ```
 - download latest release from [here](https://github.com/IceDynamix/reliquary-archiver/releases/)
 - **Launch the game and get to this screen. Do not go into the game yet**
-![main menu start screen](./hsr_hyperdrive.jpg)
+  ![main menu start screen](./hsr_hyperdrive.jpg)
 - run the archiver executable and wait until it says "listening with a timeout"
-![archiver listening for timeout](./listening_for_timeout.png)
+  ![archiver listening for timeout](./listening_for_timeout.png)
 - start the game
 - if successful, the archiver should output a file to `archiver_output.json`
-![archiver visual guide](./archiver_visual_guide.gif)
+  ![archiver visual guide](./archiver_visual_guide.gif)
 
 you might have to disable your VPN or enable/disable wifi!
 
@@ -45,19 +46,21 @@ Options:
 ```
 
 to customize logging, either
+
 - set the verbose flags
-- or set `RUST_LOG` env variable to customize logging, see [here](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives)
+- or set `RUST_LOG` env variable to customize logging,
+  see [here](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives)
 
 to output logs to a file, provide `--log-path <path>`. file logs will always be trace-level.
 
 ## build from source
 
 - follow instructions [here](https://github.com/rust-pcap/pcap?tab=readme-ov-file#building)
-  - for me on windows, adding the `Packet.lib` and `wpcap.lib` from the sdk (check the x64 or arm dir)
-    to this directory was enough to link successfully
+    - for me on windows, adding the `Packet.lib` and `wpcap.lib` from the sdk (check the x64 or arm dir)
+      to this directory was enough to link successfully
 - `cargo build` / `cargo run`
 
-note that the necessary resource files are downloaded in the build script and compiled into the binary.
+note that the necessary resource files are downloaded in the build script (`build.rs`) and compiled into the binary.
 
 ## related projects
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::File;
 use std::path::Path;
@@ -6,48 +7,88 @@ use reliquary::resource::excel::{
     AvatarConfigMap, AvatarSkillTreeConfigMap, EquipmentConfigMap, MultiplePathAvatarConfigMap,
     RelicConfigMap, RelicMainAffixConfigMap, RelicSetConfigMap, RelicSubAffixConfigMap,
 };
-use reliquary::resource::ResourceMap;
+use reliquary::resource::{ResourceMap, TextMapEntry};
+use ureq::serde::de::DeserializeOwned;
+use ureq::serde::Serialize;
 use ureq::serde_json::Value;
 
 const BASE_RESOURCE_URL: &str = "https://gitlab.com/Dimbreath/turnbasedgamedata/-/raw/main";
 const KEY_URL: &str =
     "https://raw.githubusercontent.com/tamilpp25/Iridium-SR/refs/heads/main/data/Keys.json";
 
+macro_rules! download_config_and_store_text_hashes {
+    ($t:ty, $field:ident, $hashes:ident) => {
+        write_to_out(
+            {
+                let url = resource_url::<$t>();
+                let value = download_as_json::<$t>(&url);
+                for cfg in value.0.iter() {
+                    $hashes.insert(cfg.$field);
+                }
+                value
+            },
+            <$t>::get_json_name(),
+        )
+    };
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-changed=Cargo.lock");
 
-    download_config::<AvatarConfigMap>();
+    // the text map is really, REALLY large (>25MB), so we're optimizing by only
+    // keeping the entries used from relevant config files where the strings are required
+    // for the export
+    let mut text_hashes: HashSet<TextMapEntry> = HashSet::new();
+
+    download_config_and_store_text_hashes!(AvatarConfigMap, AvatarName, text_hashes);
+    download_config_and_store_text_hashes!(EquipmentConfigMap, EquipmentName, text_hashes);
+    download_config_and_store_text_hashes!(RelicSetConfigMap, SetName, text_hashes);
+
     download_config::<AvatarSkillTreeConfigMap>();
-    download_config::<EquipmentConfigMap>();
     download_config::<MultiplePathAvatarConfigMap>();
     download_config::<RelicConfigMap>();
     download_config::<RelicMainAffixConfigMap>();
-    download_config::<RelicSetConfigMap>();
     download_config::<RelicSubAffixConfigMap>();
 
-    download_and_write_to_out(
-        "TextMapEN.json",
-        format!("{BASE_RESOURCE_URL}/TextMap/TextMapEN.json").as_str(),
+    save_text_map(&text_hashes, "EN");
+
+    write_to_out(download_as_json::<Value>(KEY_URL), "keys.json");
+}
+
+fn save_text_map(hashes: &HashSet<TextMapEntry>, language: &str) {
+    let hashes: HashSet<String> = hashes.iter().map(|k| k.Hash.to_string()).collect();
+
+    let file_name = format!("TextMap{language}.json");
+
+    let text_map_url = format!("{BASE_RESOURCE_URL}/TextMap/{file_name}");
+    let text_map: HashMap<String, String> =
+        download_as_json::<HashMap<String, String>>(&text_map_url)
+            .into_iter()
+            .filter(|(k, _)| hashes.contains(k))
+            .collect();
+
+    write_to_out(text_map, &file_name);
+}
+
+fn download_config<T: ResourceMap + DeserializeOwned + Serialize>() {
+    write_to_out(
+        download_as_json::<T>(resource_url::<T>().as_str()),
+        T::get_json_name(),
     );
-    download_and_write_to_out("keys.json", KEY_URL);
 }
 
-fn download_config<T: ResourceMap>() {
-    let file_name = T::get_json_name();
-
-    let url = format!("{BASE_RESOURCE_URL}/ExcelOutput/{file_name}");
-
-    download_and_write_to_out(file_name, &url);
+fn resource_url<T: ResourceMap>() -> String {
+    format!("{BASE_RESOURCE_URL}/ExcelOutput/{}", T::get_json_name())
 }
 
-fn download_and_write_to_out(file: &str, url: &str) {
-    // downloaded files are in pretty format, deserialize and serialize
-    // to compress file size
-    let value: Value = ureq::get(url).call().unwrap().into_json().unwrap();
+fn download_as_json<T: DeserializeOwned>(url: &str) -> T {
+    ureq::get(url).call().unwrap().into_json().unwrap()
+}
 
+fn write_to_out<T: DeserializeOwned + Serialize>(value: T, file_name: &str) {
     let out_dir = env::var_os("OUT_DIR").unwrap();
-    let out_path = Path::new(&out_dir).join(file);
+    let out_path = Path::new(&out_dir).join(file_name);
 
     let mut file = File::create(out_path).unwrap();
 


### PR DESCRIPTION
we check the configs to see which text map entries are actually used and only those are retained. this is relevant, because the entire textmap is quite large (25MB) and is embedded into the executable, which also bloats its size (30.4MB)

text map size: 25.7MB -> 7.042kB (0.0274%)
executable size: 30.4MB -> 6.36MB (20.92%)

this also makes it reasonable to support multiple export languages in the future (https://github.com/IceDynamix/reliquary-archiver/issues/43), which wasnt possilble before because every text map wouldve had to been embedded as well, bloating the size even more. even worse for languages like thai, whose textmap is 50MB.