### PR TITLE
fix: defer mismatched version packets from client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,8 +2139,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reliquary"
-version = "13.0.0"
-source = "git+https://github.com/IceDynamix/reliquary?tag=v13.0.0#e19b81d796f8b85ce962f584b09a03597d854cfb"
+version = "13.1.0"
+source = "git+https://github.com/IceDynamix/reliquary?tag=v13.1.0#d40d406ea66042d59d96069f7570c1d008b378c7"
 dependencies = [
  "base64",
  "etherparse",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "reliquary-proc-macro"
 version = "0.1.1"
-source = "git+https://github.com/IceDynamix/reliquary?tag=v13.0.0#e19b81d796f8b85ce962f584b09a03597d854cfb"
+source = "git+https://github.com/IceDynamix/reliquary?tag=v13.1.0#d40d406ea66042d59d96069f7570c1d008b378c7"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.139"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 ureq = { version = "2.12.1" }
-reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v13.0.0", features = [
+reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v13.1.0", features = [
     "proto-rqa",
 ] }
 ctrlc = "3.4.5"
@@ -46,7 +46,7 @@ windows = { version = "0.61", features = [
 
 [build-dependencies]
 ureq = { version = "2.12.1", features = ["json"] }
-reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v13.0.0", features = [
+reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v13.1.0", features = [
     "proto-rqa",
 ] }
 


### PR DESCRIPTION
Fixes #120 

If we receive client packets which are sent after the server sets the new encryption key, but before we actually see the packet from the server which sets the new encryption key, then we would not be able to read the command. With [this change](https://github.com/IceDynamix/reliquary/commit/d40d406ea66042d59d96069f7570c1d008b378c7), these packets are detected and deferred until the session key has been reset.