### PR TITLE
add warnings for common errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -726,7 +726,7 @@ async fn live_capture(
                                             GameCommandError::DecryptionKeyMissing => {
                                                 // version is not supported, there's no point in capturing
                                                 warn!(
-                                                    "This game version is not supported yet. It takes a few days for Reliquary Archiver to get updated to new versions. Please try again in a few days."
+                                                    "This game version is not supported yet. It usually takes a few days for Reliquary Archiver to get updated for new versions. Please try again at a later point."
                                                 );
                                                 break 'recv;
                                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use futures::lock::Mutex as FuturesMutex;
 use futures::{FutureExt, StreamExt, future, select};
 use reliquary::network::command::GameCommandError;
 use reliquary::network::command::command_id::{PlayerLoginFinishScRsp, PlayerLoginScRsp};
-use reliquary::network::{ConnectionPacket, GamePacket, GameSniffer, KcpError, NetworkError};
+use reliquary::network::{ConnectionPacket, ConnectionPacketError, GamePacket, GameSniffer, KcpError, NetworkError};
 use tokio::pin;
 use tracing::instrument::WithSubscriber;
 use tracing::level_filters::LevelFilter;
@@ -759,7 +759,13 @@ async fn live_capture(
                     Err(e) => {
                         warn!(%e);
                         match e {
-                            NetworkError::ConnectionPacket(_) => {
+                            NetworkError::ConnectionPacket(e) => {
+                                if let ConnectionPacketError::TransportLayerNotPresent = e {
+                                    warn!(
+                                        "This error tends to happen when using VPNs or similar programs. Please disable them and try again."
+                                    );
+                                }
+
                                 // Connection errors are not fatal as all network interfaces are funneled through the same stream
                                 // Just mark this source as poisoned and continue listening on other sources
                                 poisoned_sources.insert(packet.source_id);

--- a/src/main.rs
+++ b/src/main.rs
@@ -725,6 +725,9 @@ async fn live_capture(
                                         match e {
                                             GameCommandError::DecryptionKeyMissing => {
                                                 // version is not supported, there's no point in capturing
+                                                warn!(
+                                                    "This game version is not supported yet. It takes a few days for Reliquary Archiver to get updated to new versions. Please try again in a few days."
+                                                );
                                                 break 'recv;
                                             }
                                             GameCommandError::HeaderTooShort { .. } | GameCommandError::CommandTooShort { .. } => {


### PR DESCRIPTION
- `GameCommandError::DecryptionKeyMissing` => let the user know rqa hasn't been updated yet
- `ConnectionPacketError::TransportLayerNotPresent` => ask to disable vpn