### PR TITLE
Update reliquary to v21.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,8 +2135,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reliquary"
-version = "20.1.0"
-source = "git+https://github.com/IceDynamix/reliquary?tag=v20.1.0#06ef50faf4e00112c6ae3a3bd203150e74b731ea"
+version = "21.0.0"
+source = "git+https://github.com/IceDynamix/reliquary?tag=v21.0.0#933410ddd4888a27d58badf784003581dcd51235"
 dependencies = [
  "base64",
  "etherparse",
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "reliquary-proc-macro"
 version = "0.1.1"
-source = "git+https://github.com/IceDynamix/reliquary?tag=v20.1.0#06ef50faf4e00112c6ae3a3bd203150e74b731ea"
+source = "git+https://github.com/IceDynamix/reliquary?tag=v21.0.0#933410ddd4888a27d58badf784003581dcd51235"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.139"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 ureq = "2.12.1"
-reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v20.1.0", features = [
+reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v21.0.0", features = [
     "proto-rqa",
 ] }
 ctrlc = "3.4.5"
@@ -50,7 +50,7 @@ windows-registry = { optional = true, version = "0.6.1" }
 
 [build-dependencies]
 ureq = { version = "2.12.1", features = ["json"] }
-reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v20.1.0", features = [
+reliquary = { git = "https://github.com/IceDynamix/reliquary", tag = "v21.0.0", features = [
     "proto-rqa",
 ] }
 

--- a/src/rgui/screens/active.rs
+++ b/src/rgui/screens/active.rs
@@ -131,14 +131,21 @@ impl ActiveScreen {
 
             return column![
                 maybe_text_shadow(
-                    Text::new("Out of Date")
+                    Text::new("Unsupported Game Version")
                         .with_font_size(24.0)
                         .with_color(TEXT_COLOR)
                         .with_paragraph_alignment(ParagraphAlignment::Center),
                     text_shadow_enabled,
                 ),
                 maybe_text_shadow(
-                    Text::new("Reliquary Archiver has not updated for the latest game version.")
+                    Text::new("This version of Reliquary Archiver is not yet compatible with the latest game version.")
+                        .with_font_size(16.0)
+                        .with_color(TEXT_COLOR)
+                        .with_paragraph_alignment(ParagraphAlignment::Center),
+                    text_shadow_enabled,
+                ),
+                maybe_text_shadow(
+                    Text::new("Every new game version requires an update, which may not be available yet.")
                         .with_font_size(16.0)
                         .with_color(TEXT_COLOR)
                         .with_paragraph_alignment(ParagraphAlignment::Center),


### PR DESCRIPTION
Updates reliquary to v21.0.0 for game version 4.3 protos.

Also clarifies the unsupported game version message in the GUI.