### PR TITLE
fix: normalize offline RAW/IP pcap payloads

### DIFF
--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -26,6 +26,52 @@ pub const PORT_RANGE: (u16, u16) = (23301, 23302);
 #[cfg(feature = "pcap")]
 pub const PCAP_FILTER: &str = "udp portrange 23301-23302";
 
+#[cfg(feature = "pcap")]
+pub fn normalize_offline_pcap_payload(linktype: ::pcap::Linktype, payload: &[u8]) -> std::result::Result<Vec<u8>, String> {
+    fn frame_ip_payload(payload: &[u8], ethertype: u16) -> Vec<u8> {
+        // Use a synthetic Ethernet header so the downstream sniffer can parse RAW/IP captures.
+        let mut framed = Vec::with_capacity(14 + payload.len());
+        framed.extend_from_slice(&[0u8; 12]);
+        framed.extend_from_slice(&ethertype.to_be_bytes());
+        framed.extend_from_slice(payload);
+        framed
+    }
+
+    let link_name = linktype.get_name().ok();
+    let is_ethernet = linktype == ::pcap::Linktype::ETHERNET || link_name.as_deref() == Some("EN10MB");
+    let is_ipv4 = linktype == ::pcap::Linktype::IPV4 || link_name.as_deref() == Some("IPV4");
+    let is_ipv6 = linktype == ::pcap::Linktype::IPV6 || link_name.as_deref() == Some("IPV6");
+    let is_raw_ip = linktype == ::pcap::Linktype::RAW || linktype.0 == 12 || link_name.as_deref() == Some("RAW");
+
+    if is_ethernet {
+        return Ok(payload.to_vec());
+    }
+
+    if payload.is_empty() {
+        return Err("packet payload is empty".to_string());
+    }
+
+    if is_ipv4 {
+        return Ok(frame_ip_payload(payload, 0x0800));
+    }
+
+    if is_ipv6 {
+        return Ok(frame_ip_payload(payload, 0x86DD));
+    }
+
+    if is_raw_ip {
+        let version = payload[0] >> 4;
+        return match version {
+            4 => Ok(frame_ip_payload(payload, 0x0800)),
+            6 => Ok(frame_ip_payload(payload, 0x86DD)),
+            _ => Err(format!("RAW packet does not start with IPv4/IPv6 header (version={version})")),
+        };
+    }
+
+    let link_name = link_name.unwrap_or_else(|| "UNKNOWN".to_string());
+    Err(format!("unsupported pcap datalink {link_name} ({})", linktype.0))
+}
+
 #[derive(Debug)]
 pub enum CaptureError {
     #[cfg(feature = "pcap")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,13 +13,13 @@ use std::sync::{Arc, LazyLock, LockResult, Mutex, TryLockResult};
 use std::time::Duration;
 
 #[cfg(feature = "pcap")]
-use capture::PCAP_FILTER;
+use capture::{normalize_offline_pcap_payload, PCAP_FILTER};
 use chrono::Local;
 use clap::Parser;
 use futures::lock::Mutex as FuturesMutex;
-use futures::{FutureExt, StreamExt, future, select};
-use reliquary::network::command::GameCommandError;
+use futures::{future, select, FutureExt, StreamExt};
 use reliquary::network::command::command_id::{PlayerLoginFinishScRsp, PlayerLoginScRsp};
+use reliquary::network::command::GameCommandError;
 use reliquary::network::{ConnectionPacket, ConnectionPacketError, GamePacket, GameSniffer, KcpError, NetworkError};
 use tokio::pin;
 use tracing::instrument::WithSubscriber;
@@ -28,7 +28,7 @@ use tracing::{debug, error, info, instrument, warn};
 use tracing_subscriber::filter::Filtered;
 use tracing_subscriber::fmt::{MakeWriter, SubscriberBuilder};
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::{EnvFilter, Layer, Registry, reload};
+use tracing_subscriber::{reload, EnvFilter, Layer, Registry};
 
 #[cfg(feature = "stream")]
 mod websocket;
@@ -39,9 +39,9 @@ mod rgui;
 #[cfg(windows)]
 mod update;
 
-use reliquary_archiver::export::Exporter;
 use reliquary_archiver::export::database::Database;
 use reliquary_archiver::export::fribbels::OptimizerExporter;
+use reliquary_archiver::export::Exporter;
 
 mod capture;
 mod scopefns;
@@ -430,8 +430,8 @@ fn tracing_init(args: &Args) {
                     2 => "debug",
                     _ => "trace",
                 }
-                .parse()
-                .unwrap(),
+                    .parse()
+                    .unwrap(),
             )
             .from_env_lossy()
     }
@@ -522,10 +522,15 @@ where
 {
     info!("Capturing from pcap file: {}", pcap_path.display());
     let mut capture = pcap::Capture::from_file(&pcap_path).expect("could not read pcap file");
+    let linktype = capture.get_datalink();
     capture.filter(PCAP_FILTER, false).unwrap();
 
     while let Ok(packet) = capture.next_packet() {
-        match file_process_packet(&mut exporter, &mut sniffer, packet.data.to_vec()) {
+        let payload = match normalize_offline_pcap_payload(linktype, packet.data) {
+            Ok(payload) => payload,
+            Err(_) => continue,
+        };
+        match file_process_packet(&mut exporter, &mut sniffer, payload) {
             ProcessResult::Continue => {}
             ProcessResult::Stop => break,
         }
@@ -568,7 +573,7 @@ where
     use tokio::sync::watch;
 
     #[cfg(feature = "stream")]
-    use crate::websocket::{PortSource, start_websocket_server};
+    use crate::websocket::{start_websocket_server, PortSource};
     use crate::worker::MultiAccountManager;
 
     #[cfg(not(feature = "stream"))]
@@ -834,9 +839,9 @@ fn escalate_to_admin() -> Result<(), Box<dyn std::error::Error>> {
     use std::os::windows::ffi::OsStrExt;
 
     use windows::Win32::System::Console::GetConsoleWindow;
-    use windows::Win32::UI::Shell::{SEE_MASK_NO_CONSOLE, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW};
-    use windows::Win32::UI::WindowsAndMessaging::{GW_OWNER, GetWindow, SW_SHOWNORMAL};
-    use windows::core::{PCWSTR, w};
+    use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SEE_MASK_NO_CONSOLE, SHELLEXECUTEINFOW};
+    use windows::Win32::UI::WindowsAndMessaging::{GetWindow, GW_OWNER, SW_SHOWNORMAL};
+    use windows::core::{w, PCWSTR};
 
     let args_str = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ use capture::{normalize_offline_pcap_payload, PCAP_FILTER};
 use chrono::Local;
 use clap::Parser;
 use futures::lock::Mutex as FuturesMutex;
-use futures::{future, select, FutureExt, StreamExt};
-use reliquary::network::command::command_id::{PlayerLoginFinishScRsp, PlayerLoginScRsp};
+use futures::{FutureExt, StreamExt, future, select};
 use reliquary::network::command::GameCommandError;
+use reliquary::network::command::command_id::{PlayerLoginFinishScRsp, PlayerLoginScRsp};
 use reliquary::network::{ConnectionPacket, ConnectionPacketError, GamePacket, GameSniffer, KcpError, NetworkError};
 use tokio::pin;
 use tracing::instrument::WithSubscriber;
@@ -28,7 +28,7 @@ use tracing::{debug, error, info, instrument, warn};
 use tracing_subscriber::filter::Filtered;
 use tracing_subscriber::fmt::{MakeWriter, SubscriberBuilder};
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::{reload, EnvFilter, Layer, Registry};
+use tracing_subscriber::{EnvFilter, Layer, Registry, reload};
 
 #[cfg(feature = "stream")]
 mod websocket;
@@ -39,9 +39,9 @@ mod rgui;
 #[cfg(windows)]
 mod update;
 
+use reliquary_archiver::export::Exporter;
 use reliquary_archiver::export::database::Database;
 use reliquary_archiver::export::fribbels::OptimizerExporter;
-use reliquary_archiver::export::Exporter;
 
 mod capture;
 mod scopefns;
@@ -430,8 +430,8 @@ fn tracing_init(args: &Args) {
                     2 => "debug",
                     _ => "trace",
                 }
-                    .parse()
-                    .unwrap(),
+                .parse()
+                .unwrap(),
             )
             .from_env_lossy()
     }
@@ -573,7 +573,7 @@ where
     use tokio::sync::watch;
 
     #[cfg(feature = "stream")]
-    use crate::websocket::{start_websocket_server, PortSource};
+    use crate::websocket::{PortSource, start_websocket_server};
     use crate::worker::MultiAccountManager;
 
     #[cfg(not(feature = "stream"))]
@@ -839,9 +839,9 @@ fn escalate_to_admin() -> Result<(), Box<dyn std::error::Error>> {
     use std::os::windows::ffi::OsStrExt;
 
     use windows::Win32::System::Console::GetConsoleWindow;
-    use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SEE_MASK_NO_CONSOLE, SHELLEXECUTEINFOW};
-    use windows::Win32::UI::WindowsAndMessaging::{GetWindow, GW_OWNER, SW_SHOWNORMAL};
-    use windows::core::{w, PCWSTR};
+    use windows::Win32::UI::Shell::{SEE_MASK_NO_CONSOLE, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW};
+    use windows::Win32::UI::WindowsAndMessaging::{GW_OWNER, GetWindow, SW_SHOWNORMAL};
+    use windows::core::{PCWSTR, w};
 
     let args_str = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -73,7 +73,7 @@ impl<Output, Intermediate> MappedSender<Output, Intermediate> {
 /// This is a more ergonomic [`stream::unfold`], which allows you to go
 /// from the "world of futures" to the "world of streams" by simply looping
 /// and publishing to an async channel from inside a [`Future`].
-pub fn stream_channel<T>(size: usize, f: impl AsyncFnOnce(mpsc::Sender<T>)) -> impl Stream<Item=T> {
+pub fn stream_channel<T>(size: usize, f: impl AsyncFnOnce(mpsc::Sender<T>)) -> impl Stream<Item = T> {
     let (sender, receiver) = mpsc::channel(size);
 
     let runner = stream::once(f(sender)).filter_map(|_| async { None });
@@ -223,7 +223,7 @@ impl MultiAccountManager {
 }
 
 #[instrument(skip_all)]
-pub fn archiver_worker(manager: Arc<Mutex<MultiAccountManager>>) -> impl Stream<Item=WorkerEvent> {
+pub fn archiver_worker(manager: Arc<Mutex<MultiAccountManager>>) -> impl Stream<Item = WorkerEvent> {
     stream_channel(100, |mut output: mpsc::Sender<WorkerEvent>| async move {
         let (sender, mut receiver) = mpsc::channel(100);
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -73,7 +73,7 @@ impl<Output, Intermediate> MappedSender<Output, Intermediate> {
 /// This is a more ergonomic [`stream::unfold`], which allows you to go
 /// from the "world of futures" to the "world of streams" by simply looping
 /// and publishing to an async channel from inside a [`Future`].
-pub fn stream_channel<T>(size: usize, f: impl AsyncFnOnce(mpsc::Sender<T>)) -> impl Stream<Item = T> {
+pub fn stream_channel<T>(size: usize, f: impl AsyncFnOnce(mpsc::Sender<T>)) -> impl Stream<Item=T> {
     let (sender, receiver) = mpsc::channel(size);
 
     let runner = stream::once(f(sender)).filter_map(|_| async { None });
@@ -223,7 +223,7 @@ impl MultiAccountManager {
 }
 
 #[instrument(skip_all)]
-pub fn archiver_worker(manager: Arc<Mutex<MultiAccountManager>>) -> impl Stream<Item = WorkerEvent> {
+pub fn archiver_worker(manager: Arc<Mutex<MultiAccountManager>>) -> impl Stream<Item=WorkerEvent> {
     stream_channel(100, |mut output: mpsc::Sender<WorkerEvent>| async move {
         let (sender, mut receiver) = mpsc::channel(100);
 
@@ -328,10 +328,11 @@ pub enum SnifferMetric {
 fn capture_from_pcap(pcap_path: std::path::PathBuf) -> Vec<capture::Packet> {
     use std::hash::{DefaultHasher, Hasher};
 
-    use crate::capture::PCAP_FILTER;
+    use crate::capture::{PCAP_FILTER, normalize_offline_pcap_payload};
 
     info!("Capturing from pcap file: {}", pcap_path.display());
     let mut capture = pcap::Capture::from_file(&pcap_path).expect("could not read pcap file");
+    let linktype = capture.get_datalink();
     capture.filter(PCAP_FILTER, false).unwrap();
 
     let mut hasher = DefaultHasher::new();
@@ -340,9 +341,13 @@ fn capture_from_pcap(pcap_path: std::path::PathBuf) -> Vec<capture::Packet> {
 
     let mut packets = Vec::new();
     while let Ok(packet) = capture.next_packet() {
+        let payload = match normalize_offline_pcap_payload(linktype, packet.data) {
+            Ok(payload) => payload,
+            Err(_) => continue,
+        };
         packets.push(capture::Packet {
             source_id,
-            data: packet.data.to_vec(),
+            data: payload,
         });
     }
 


### PR DESCRIPTION
Fixes #173 by adding an Ethernet header to packets without one. I tested with the files from my phone but not any other ones.

I know enough Rust to be able to answer questions and implement change requests.